### PR TITLE
Fix recent todo functionality on saveNewItem fx

### DIFF
--- a/script.js
+++ b/script.js
@@ -140,6 +140,7 @@ function enterEdit(e) {
 function enterSave(e) {
   if(e.keyCode === 13 && ($('.input-title').val() !== '') && ($('.input-body').val() !== '')){
     enableSaveButton13();
+    showTenTasks();
   }
 }
 
@@ -237,6 +238,7 @@ function prepend(task)  {
     var body = $('.input-body').val();
     var task = new Task(title, body);
     prepend(task);
+    showTenTasks();
     clearInputFields();
     sendToStorage(task);
     disableSaveButton();


### PR DESCRIPTION
So I realized that we forgot to add that showTen function to our "enter" key button.  And I also added it in SaveNewItem function directly after we prepend the item.  So it works now! Yay!